### PR TITLE
Changed column 'Usage Per/Min to 'Local Usage Per/Min'.

### DIFF
--- a/private/views/pages/production_line.php
+++ b/private/views/pages/production_line.php
@@ -237,7 +237,7 @@ global $changelog;
                         <th scope="col">Recipe</th>
                         <th scope="col">Quantity Per/min</th>
                         <th scope="col">Product</th>
-                        <th scope="col">Usage Per/min</th>
+                        <th scope="col">Local Usage Per/min</th>
                         <th scope="col">Export Per/min</th>
                     </tr>
                     </thead>

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "1.7.6",
+    "date": "Februari 22 2025",
+    "changes": [
+      "Changed column 'Usage Per/Min to 'Local Usage Per/Min'."
+    ]
+  },
+  {
+    "version": "1.7.5",
+    "date": "Februari 14 2025",
+    "changes": [
+      "Fixed not able to delete account.",
+      "Fixed Import issue where the user created power rows where always true."
+    ]
+  },
+  {
     "version": "1.7.5",
     "date": "Februari 14 2025",
     "changes": [


### PR DESCRIPTION
This pull request includes changes to the `private/views/pages/production_line.php` and `public/changelog.json` files to update a column name and document recent changes. The most important changes are:

Updates to column names:

* [`private/views/pages/production_line.php`](diffhunk://#diff-8a68c43f673fb6c9b89290fee998dd411fe432d117e5e2a57e9afc8ac6e5261bL240-R240): Changed the column name from 'Usage Per/min' to 'Local Usage Per/min'.

Documentation updates:

* [`public/changelog.json`](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R2-R16): Added version 1.7.6 with the change "Changed column 'Usage Per/Min' to 'Local Usage Per/Min'."
* [`public/changelog.json`](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R2-R16): Added version 1.7.5 with fixes for account deletion and an import issue.