### PR TITLE
fixxed issues with saving

### DIFF
--- a/private/ajax/saveProductionLine.php
+++ b/private/ajax/saveProductionLine.php
@@ -80,7 +80,6 @@ foreach ($powerRows as $row) {
     $totalPower += $row['Consumption'];
 }
 $oldAndNewIds = ProductionLines::saveProductionLine($importsData, $productionData, $powerData, $totalPower, $productionLineId);
-var_dump($oldAndNewIds);
 $checklist = $data['checklist'];
 $checklists = [];
 foreach ($checklist as $check) {

--- a/private/ajax/saveProductionLine.php
+++ b/private/ajax/saveProductionLine.php
@@ -79,15 +79,15 @@ foreach ($powerRows as $row) {
     ];
     $totalPower += $row['Consumption'];
 }
-
 $oldAndNewIds = ProductionLines::saveProductionLine($importsData, $productionData, $powerData, $totalPower, $productionLineId);
-
+var_dump($oldAndNewIds);
 $checklist = $data['checklist'];
 $checklists = [];
 foreach ($checklist as $check) {
 //    if id is in old id change it to the new id
     $newId = null;
     if ($oldAndNewIds !== false) {
+
         foreach ($oldAndNewIds as $oldAndNewId) {
             if ($oldAndNewId['old'] == $check['productionRow']['row_id']) {
                 $newId = $oldAndNewId['new'];
@@ -106,7 +106,9 @@ foreach ($checklist as $check) {
 if ($checklists) {
 
     if (!Checklist::saveChecklist($checklists, $productionLineId)) {
-        echo json_encode(['error' => 'Failed to update production line']);
+        echo json_encode(['error' => 'Failed to update production line checklist']);
+        http_response_code(500);
+        error_log('Failed to update production line checklist for production line ID: ' . $productionLineId);
         exit();
     }
 }
@@ -118,4 +120,5 @@ if ($oldAndNewIds !== false) {
 
 
 echo json_encode(['error' => 'Failed to update production line']);
+http_response_code(500);
 exit();

--- a/private/controllers/Checklist.php
+++ b/private/controllers/Checklist.php
@@ -28,6 +28,7 @@ class Checklist {
             return true;
         } catch (Exception $e) {
             $database->rollBack();
+            error_log('Failed to save checklist for production line ID: ' . $productionLineId . ' - ' . $e->getMessage());
             return false;
         }
     }

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "1.11.1",
+    "date": "August 10 2025",
+    "changes": [
+      "Fixed: Saving returning error."
+    ]
+  },
+  {
     "version": "1.11.0",
     "date": "August 8 2025",
     "changes": [


### PR DESCRIPTION
This pull request improves error handling and debugging for the production line and checklist saving processes, ensuring clearer error messages, HTTP status codes, and better logging for failures. It also addresses ID mapping for production records with non-numeric IDs. The most important changes are:

**Error Handling and Logging Improvements:**

* Added specific error messages, HTTP 500 status codes, and error logging when saving the production line or checklist fails in `saveProductionLine.php`. This makes debugging and client-side error handling easier. [[1]](diffhunk://#diff-1278fcf11b6e15b199c6faf462f89f725a09f284d01888091d6e8d41a97fc269L109-R110) [[2]](diffhunk://#diff-1278fcf11b6e15b199c6faf462f89f725a09f284d01888091d6e8d41a97fc269R122)
* Added error logging in `Checklist::saveChecklist` and `ProductionLines::saveProductionLine` methods to record details of failures, including the production line ID and exception messages. [[1]](diffhunk://#diff-a397fc57a23694554a7ec37158e2c1308763c7ddabb1524793cd4386027e3debR31) [[2]](diffhunk://#diff-2da91c23d1986aaba3316235cfad5923af790f84ea0ad2fa47e55221bd1f6b53R161)

**Production ID Mapping Fixes:**

* Updated `ProductionLines::saveProductionLine` to handle cases where production IDs are UUIDs (non-numeric), ensuring correct mapping between old and new IDs and preventing potential mismatches.

**Changelog Update:**

* Updated `changelog.json` with version 1.11.1, noting the fix for saving errors.